### PR TITLE
Private datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ JSON content with the following structure:
 
 `/presign`
 
-**Methos:** `POST`
+**Methos:** `GET`
 
 **Query Parameters:**
 
@@ -166,13 +166,6 @@ JSON content with the following structure:
 **Headers:**
 
  - `Auth-Token` - permission token (can be used instead of the `jwt` query parameter)
-
-**Body**
-
-{
-  "url": "https://rawstore.datahub.io/ownername/dataset/mydata.csv",
-  "owner": "ownername"
-}
 
 **Returns:**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BitStore is a DataHub microservice for storing blobs i.e. files. It is a lightwe
 
 ## Quick Start
 
-# Clone the repo and install 
+# Clone the repo and install
 
 `make install`
 
@@ -27,14 +27,14 @@ BitStore is a DataHub microservice for storing blobs i.e. files. It is a lightwe
   ```
 * `STORAGE_PATH_PATTERN` - pattern for generating the storage path in the objectstore for a given rile. That is, `object_store_path = make_path(STORAGE_PATH_PATTERN.format{fileinfo})`. May contain any format string available for a file in authorize API including
     - `{path}` (relative path to file in package)
-    - `{md5}`. 
+    - `{md5}`.
     - `{basename}` which is the filename, extracted from the `{path}`
     - `{dirname}` which is the dirname, extracted from the `{path}`
     - `{extension}` which is the extension of the filename
     - `{md5}` (and `{md5_hex}` which is the md5 in hex form)   
-    Note: in addition to file info the owner and dataset (name) are available as `{owner}` and `{dataset}`. 
+    Note: in addition to file info the owner and dataset (name) are available as `{owner}` and `{dataset}`.
  Examples:
-  * `custom/path/{owner}/{dataset}/{path}` will, given `{owner: datahq, name: datax, path: data/file.csv}` will end up with `custom/path/datahq/datax/data/file.csv` 
+  * `custom/path/{owner}/{dataset}/{path}` will, given `{owner: datahq, name: datax, path: data/file.csv}` will end up with `custom/path/datahq/datax/data/file.csv`
   * `{md5}` - storage path is md5 hash of the file (assuming md5 hash is provided)
 
 Note: requested permissions to auth server will be like:
@@ -143,10 +143,42 @@ JSON content with the following structure:
 ```json
 {
     "prefixes": [
-        'https://datastore.openspending.org/123456789',
-        ...
+        "https://datastore.openspending.org/123456789",
     ]
 }
 ```
 
 `prefixes` is the list of possible prefixes for an uploaded file for this user.
+
+
+### Check and Generate S3 Presigned URL for private objects
+
+`/presign`
+
+**Methos:** `POST`
+
+**Query Parameters:**
+
+ - `jwt` - permission token (received from `/user/authorize`)
+ - `url` - original URL for S3 object
+ - `ownerid` - authenticated user Id
+
+**Headers:**
+
+ - `Auth-Token` - permission token (can be used instead of the `jwt` query parameter)
+
+**Body**
+
+{
+  "url": "https://rawstore.datahub.io/ownername/dataset/mydata.csv",
+  "owner": "ownername"
+}
+
+**Returns:**
+
+Original or Pre-Signed S3 URL:
+```json
+{
+    "url": "https://s3.amazonaws.com/rawstore/ownername/dataset/maydata.csv?x=y",
+}
+```

--- a/bitstore/blueprint.py
+++ b/bitstore/blueprint.py
@@ -26,11 +26,23 @@ def make_blueprint():
             auth_token = request.values.get('jwt')
         return controllers.info(auth_token)
 
+    def presign():
+        auth_token = request.headers.get('Auth-Token') or request.values.get('jwt')
+        try:
+            req_payload = json.loads(request.data.decode())
+            url = req_payload.get('url') or request.values.get('url')
+            ownerid = req_payload.get('ownerid') or request.values.get('ownerid')
+            return controllers.presign(auth_token, url, ownerid)
+        except (json.JSONDecodeError, ValueError) as e:
+            return Response(str(e), status=400)
+
     # Register routes
     blueprint.add_url_rule(
             'info', 'info', info, methods=['GET'])
     blueprint.add_url_rule(
             'authorize', 'authorize', authorize, methods=['POST'])
+    blueprint.add_url_rule(
+            'presign', 'presign', presign, methods=['POST'])
     blueprint.add_url_rule(
             '/', 'authorize', authorize, methods=['POST'])
 

--- a/bitstore/blueprint.py
+++ b/bitstore/blueprint.py
@@ -28,13 +28,9 @@ def make_blueprint():
 
     def presign():
         auth_token = request.headers.get('Auth-Token') or request.values.get('jwt')
-        try:
-            req_payload = json.loads(request.data.decode())
-            url = req_payload.get('url') or request.values.get('url')
-            ownerid = req_payload.get('ownerid') or request.values.get('ownerid')
-            return controllers.presign(auth_token, url, ownerid)
-        except (json.JSONDecodeError, ValueError) as e:
-            return Response(str(e), status=400)
+        url = request.values.get('url')
+        ownerid = request.values.get('ownerid')
+        controllers.presign(auth_token, url, ownerid)
 
     # Register routes
     blueprint.add_url_rule(
@@ -42,7 +38,7 @@ def make_blueprint():
     blueprint.add_url_rule(
             'authorize', 'authorize', authorize, methods=['POST'])
     blueprint.add_url_rule(
-            'presign', 'presign', presign, methods=['POST'])
+            'presign', 'presign', presign, methods=['GET'])
     blueprint.add_url_rule(
             '/', 'authorize', authorize, methods=['POST'])
 

--- a/bitstore/controllers.py
+++ b/bitstore/controllers.py
@@ -192,7 +192,8 @@ def presign(auth_token, url, ownerid=None):
             Params={
                 'Bucket': bucket,
                 'Key': key
-            })
+            },
+            ExpiresIn=3600*24)
         return json.dumps({'url': signed_url})
     except Exception as exception:
         logging.exception('Bad request')

--- a/bitstore/controllers.py
+++ b/bitstore/controllers.py
@@ -187,6 +187,10 @@ def presign(auth_token, url, ownerid=None):
         bucket = parsed_url.netloc
         key = parsed_url.path.lstrip('/')
 
+        # Make sure file belongs to user (only in case of pkgstore)
+        if config['STORAGE_BUCKET_NAME'] != bucket and (ownerid not in url):
+            return Response(status=403)
+
         signed_url = s3.generate_presigned_url(
             ClientMethod='get_object',
             Params={

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,4 @@ coveralls
 pytest
 pytest-cov
 moto
+requests-mock

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -164,3 +164,4 @@ class DataStoreTest(unittest.TestCase):
         self.services.verify = Mock(return_value=True)
         out = json.loads(presign(AUTH_TOKEN, url, 'owner'))
         self.assertTrue(out['url'].startswith('https://s3.amazonaws.com/buckbuck/owner/name'))
+        self.assertTrue('Expires=86400' in out['url'])

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -134,7 +134,7 @@ class DataStoreTest(unittest.TestCase):
     def test__checkurl__returns_url_as_is_if_not_forbidden(self, m):
         presign = module.presign
         url = 'http://test.com'
-        m.get(url, status_code=200)
+        m.head(url, status_code=200)
         out = json.loads(presign(AUTH_TOKEN, url, 'owner'))
         self.assertEqual(out['url'], 'http://test.com')
 
@@ -142,25 +142,25 @@ class DataStoreTest(unittest.TestCase):
     def test__checkurl__not_authorized(self, m):
         presign = module.presign
         url = 'http://{}/{}/{}'.format(module.config['STORAGE_BUCKET_NAME'], 'owner', 'name')
-        m.get(url, status_code=403)
+        m.head(url, status_code=403)
         self.services.verify = Mock(return_value=False)
         out = presign(AUTH_TOKEN, url, 'owner')
-        self.assertEqual(out.status, '401 UNAUTHORIZED')
+        self.assertEqual(out.status, '403 FORBIDDEN')
 
     @requests_mock.mock()
     def test__checkurl__no_user(self, m):
         presign = module.presign
         url = 'http://{}/{}/{}'.format(module.config['STORAGE_BUCKET_NAME'], 'owner', 'name')
-        m.get(url, status_code=403)
+        m.head(url, status_code=403)
         self.services.verify = Mock(return_value=False)
         out = presign(AUTH_TOKEN, url)
-        self.assertEqual(out.status, '400 BAD REQUEST')
+        self.assertEqual(out.status, '401 UNAUTHORIZED')
 
     @requests_mock.mock()
     def test__checkurl__signes_url(self, m):
         presign = module.presign
         url = 'http://{}/{}/{}'.format(module.config['STORAGE_BUCKET_NAME'], 'owner', 'name')
-        m.get(url, status_code=403)
+        m.head(url, status_code=403)
         self.services.verify = Mock(return_value=True)
         out = json.loads(presign(AUTH_TOKEN, url, 'owner'))
         self.assertTrue(out['url'].startswith('https://s3.amazonaws.com/buckbuck/owner/name'))

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -138,6 +138,7 @@ class DataStoreTest(unittest.TestCase):
         out = json.loads(presign(AUTH_TOKEN, url, 'owner'))
         self.assertEqual(out['url'], 'http://test.com')
 
+
     @requests_mock.mock()
     def test__checkurl__not_authorized(self, m):
         presign = module.presign
@@ -155,6 +156,15 @@ class DataStoreTest(unittest.TestCase):
         self.services.verify = Mock(return_value=False)
         out = presign(AUTH_TOKEN, url)
         self.assertEqual(out.status, '401 UNAUTHORIZED')
+
+    @requests_mock.mock()
+    def test__checkurl__returns_forbidden_if_url_does_not_owned_by_owner(self, m):
+        presign = module.presign
+        url = 'http://{}/{}/{}'.format('pkgstore', 'owner', 'name')
+        m.head(url, status_code=403)
+        self.services.verify = Mock(return_value=True)
+        out = presign(AUTH_TOKEN, url, 'notowner')
+        self.assertEqual(out.status, '403 FORBIDDEN')
 
     @requests_mock.mock()
     def test__checkurl__signes_url(self, m):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps=
   pytest-cov
   moto
   coverage
+  requests-mock
   -rrequirements.txt
 passenv=
   CI
@@ -24,4 +25,3 @@ commands=
     --cov-config tox.ini \
     --cov-report term-missing \
     {posargs}
- 


### PR DESCRIPTION
* allows setting ACL private according to the findability sent from CLI 
* Endpoint for generating S3 pre-signed URLs (if necessary) for requested URL